### PR TITLE
Display progress info on SIGUSR1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 
 dnl Check for standard headers
-AC_CHECK_HEADERS([stdio.h stdlib.h string.h unistd.h])
+AC_CHECK_HEADERS([stdio.h stdlib.h string.h unistd.h math.h])
 
 dnl Check for functions
 AC_CHECK_FUNCS([malloc free])
@@ -17,6 +17,8 @@ AC_CHECK_FUNCS([memcmp memset strlen strncpy])
 AC_CHECK_FUNCS([getopt])
 
 dnl Check for libraries
+AC_CHECK_LIB(m, pow, [], AC_MSG_ERROR([math library required]))
+
 AC_CHECK_LIB(pthread, pthread_create, [], AC_MSG_ERROR([POSIX threads library required]))
 AC_CHECK_HEADERS(pthread.h, [], AC_MSG_ERROR([POSIX threads headers required]))
 


### PR DESCRIPTION
Hello,

I was using your code to try to recover a btc wallet password and thought it would be nice to be able to get some data about progress.

With this patch bruteforce-wallet will print out some basic stats when interrupted with SIGUSR1 (like dd for example).

Not 100% confident about the search space cardinality math there - you might want to take a look.

Thank you for your great work.